### PR TITLE
Drupalpod support for Commerce

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,0 +1,260 @@
+name: ddev-gitpod
+type: drupal10
+docroot: web
+php_version: "8.1"
+webserver_type: nginx-fpm
+router_http_port: "80"
+router_https_port: "443"
+xdebug_enabled: false
+additional_hostnames: []
+additional_fqdns: []
+database:
+  type: mariadb
+  version: "10.4"
+nfs_mount_enabled: false
+mutagen_enabled: false
+use_dns_when_possible: true
+composer_version: "2"
+web_environment: []
+nodejs_version: "16"
+
+# Key features of ddev's config.yaml:
+
+# name: <projectname> # Name of the project, automatically provides
+#   http://projectname.ddev.site and https://projectname.ddev.site
+
+# type: <projecttype>  # drupal6/7/8, backdrop, typo3, wordpress, php
+
+# docroot: <relative_path> # Relative path to the directory containing index.php.
+
+# php_version: "7.4"  # PHP version to use, "5.6", "7.0", "7.1", "7.2", "7.3", "7.4", "8.0", "8.1", "8.2"
+
+# You can explicitly specify the webimage but this
+# is not recommended, as the images are often closely tied to ddev's' behavior,
+# so this can break upgrades.
+
+# webimage: <docker_image>  # nginx/php docker image.
+
+# database:
+#   type: <dbtype> # mysql, mariadb
+#   version: <version> # database version, like "10.3" or "8.0"
+# Note that mariadb_version or mysql_version from v1.18 and earlier
+# will automatically be converted to this notation with just a "ddev config --auto"
+
+# router_http_port: <port>  # Port to be used for http (defaults to port 80)
+# router_https_port: <port> # Port for https (defaults to 443)
+
+# xdebug_enabled: false  # Set to true to enable xdebug and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xdebug" to enable xdebug and "ddev xdebug off" to disable it work better,
+# as leaving xdebug enabled all the time is a big performance hit.
+
+# xhprof_enabled: false  # Set to true to enable xhprof and "ddev start" or "ddev restart"
+# Note that for most people the commands
+# "ddev xhprof" to enable xhprof and "ddev xhprof off" to disable it work better,
+# as leaving xhprof enabled all the time is a big performance hit.
+
+# webserver_type: nginx-fpm  # or apache-fpm
+
+# timezone: Europe/Berlin
+# This is the timezone used in the containers and by PHP;
+# it can be set to any valid timezone,
+# see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+# For example Europe/Dublin or MST7MDT
+
+# composer_root: <relative_path>
+# Relative path to the composer root directory from the project root. This is
+# the directory which contains the composer.json and where all Composer related
+# commands are executed.
+
+# composer_version: "2"
+# You can set it to "" or "2" (default) for Composer v2 or "1" for Composer v1
+# to use the latest major version available at the time your container is built.
+# It is also possible to use each other Composer version channel. This includes:
+#   - 2.2 (latest Composer LTS version)
+#   - stable
+#   - preview
+#   - snapshot
+# Alternatively, an explicit Composer version may be specified, for example "2.2.18".
+# To reinstall Composer after the image was built, run "ddev debug refresh".
+
+# nodejs_version: "16"
+# change from the default system Node.js version to another supported version, like 12, 14, 17, 18.
+# Note that you can use 'ddev nvm' or nvm inside the web container to provide nearly any
+# Node.js version, including v6, etc.
+
+# additional_hostnames:
+#  - somename
+#  - someothername
+# would provide http and https URLs for "somename.ddev.site"
+# and "someothername.ddev.site".
+
+# additional_fqdns:
+#  - example.com
+#  - sub1.example.com
+# would provide http and https URLs for "example.com" and "sub1.example.com"
+# Please take care with this because it can cause great confusion.
+
+# upload_dir: custom/upload/dir
+# would set the destination path for ddev import-files to <docroot>/custom/upload/dir
+# When mutagen is enabled this path is bind-mounted so that all the files
+# in the upload_dir don't have to be synced into mutagen
+
+# working_dir:
+#   web: /var/www/html
+#   db: /home
+# would set the default working directory for the web and db services.
+# These values specify the destination directory for ddev ssh and the
+# directory in which commands passed into ddev exec are run.
+
+# omit_containers: [db, dba, ddev-ssh-agent]
+# Currently only these containers are supported. Some containers can also be
+# omitted globally in the ~/.ddev/global_config.yaml. Note that if you omit
+# the "db" container, several standard features of ddev that access the
+# database container will be unusable. In the global configuration it is also
+# possible to omit ddev-router, but not here.
+
+# nfs_mount_enabled: false
+# Great performance improvement but requires host configuration first.
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#nfs
+
+# mutagen_enabled: false
+# Performance improvement using mutagen asynchronous updates.
+# See https://ddev.readthedocs.io/en/latest/users/install/performance/#mutagen
+
+# fail_on_hook_fail: False
+# Decide whether 'ddev start' should be interrupted by a failing hook
+
+# host_https_port: "59002"
+# The host port binding for https can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_webserver_port: "59001"
+# The host port binding for the ddev-webserver can be explicitly specified. It is
+# dynamic unless otherwise specified.
+# This is not used by most people, most people use the *router* instead
+# of the localhost port.
+
+# host_db_port: "59002"
+# The host port binding for the ddev-dbserver can be explicitly specified. It is dynamic
+# unless explicitly specified.
+
+# phpmyadmin_port: "8036"
+# phpmyadmin_https_port: "8037"
+# The PHPMyAdmin ports can be changed from the default 8036 and 8037
+
+# host_phpmyadmin_port: "8036"
+# The phpmyadmin (dba) port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be specified and bound.
+
+# mailhog_port: "8025"
+# mailhog_https_port: "8026"
+# The MailHog ports can be changed from the default 8025 and 8026
+
+# host_mailhog_port: "8025"
+# The mailhog port is not normally bound on the host at all, instead being routed
+# through ddev-router, but it can be bound directly to localhost if specified here.
+
+# webimage_extra_packages: [php7.4-tidy, php-bcmath]
+# Extra Debian packages that are needed in the webimage can be added here
+
+# dbimage_extra_packages: [telnet,netcat]
+# Extra Debian packages that are needed in the dbimage can be added here
+
+# use_dns_when_possible: true
+# If the host has internet access and the domain configured can
+# successfully be looked up, DNS will be used for hostname resolution
+# instead of editing /etc/hosts
+# Defaults to true
+
+# project_tld: ddev.site
+# The top-level domain used for project URLs
+# The default "ddev.site" allows DNS lookup via a wildcard
+# If you prefer you can change this to "ddev.local" to preserve
+# pre-v1.9 behavior.
+
+# ngrok_args: --basic-auth username:pass1234
+# Provide extra flags to the "ngrok http" command, see
+# https://ngrok.com/docs#http or run "ngrok http -h"
+
+# disable_settings_management: false
+# If true, ddev will not create CMS-specific settings files like
+# Drupal's settings.php/settings.ddev.php or TYPO3's AdditionalConfiguration.php
+# In this case the user must provide all such settings.
+
+# You can inject environment variables into the web container with:
+# web_environment:
+# - SOMEENV=somevalue
+# - SOMEOTHERENV=someothervalue
+
+# no_project_mount: false
+# (Experimental) If true, ddev will not mount the project into the web container;
+# the user is responsible for mounting it manually or via a script.
+# This is to enable experimentation with alternate file mounting strategies.
+# For advanced users only!
+
+# bind_all_interfaces: false
+# If true, host ports will be bound on all network interfaces,
+# not just the localhost interface. This means that ports
+# will be available on the local network if the host firewall
+# allows it.
+
+# default_container_timeout: 120
+# The default time that ddev waits for all containers to become ready can be increased from
+# the default 120. This helps in importing huge databases, for example.
+
+#web_extra_exposed_ports:
+#- name: nodejs
+#  container_port: 3000
+#  http_port: 2999
+#  https_port: 3000
+#- name: something
+#  container_port: 4000
+#  https_port: 4000
+#  http_port: 3999
+# Allows a set of extra ports to be exposed via ddev-router
+# The port behavior on the ddev-webserver must be arranged separately, for example
+# using web_extra_daemons.
+# For example, with a web app on port 3000 inside the container, this config would
+# expose that web app on https://<project>.ddev.site:9999 and http://<project>.ddev.site:9998
+# web_extra_exposed_ports:
+#  - container_port: 3000
+#    http_port: 9998
+#    https_port: 9999
+
+#web_extra_daemons:
+#- name: "http-1"
+#  command: "/var/www/html/node_modules/.bin/http-server -p 3000"
+#  directory: /var/www/html
+#- name: "http-2"
+#  command: "/var/www/html/node_modules/.bin/http-server /var/www/html/sub -p 3000"
+#  directory: /var/www/html
+
+# override_config: false
+# By default, config.*.yaml files are *merged* into the configuration
+# But this means that some things can't be overridden
+# For example, if you have 'nfs_mount_enabled: true'' you can't override it with a merge
+# and you can't erase existing hooks or all environment variables.
+# However, with "override_config: true" in a particular config.*.yaml file,
+# 'nfs_mount_enabled: false' can override the existing values, and
+# hooks:
+#   post-start: []
+# or
+# web_environment: []
+# or
+# additional_hostnames: []
+# can have their intended affect. 'override_config' affects only behavior of the
+# config.*.yaml file it exists in.
+
+# Many ddev commands can be extended to run tasks before or after the
+# ddev command is executed, for example "post-start", "post-import-db",
+# "pre-composer", "post-composer"
+# See https://ddev.readthedocs.io/en/stable/users/extend/custom-commands/ for more
+# information on the commands that can be extended and the tasks you can define
+# for them. Example:
+#hooks:
+# post-import-db:
+#   - exec: drush cr
+#   - exec: drush updb

--- a/.ddev/docker-compose.network-mtu.yaml
+++ b/.ddev/docker-compose.network-mtu.yaml
@@ -1,0 +1,18 @@
+# Temporary fix for network issues when running composer inside ddev container (in Gitpod)
+# 
+# Since Gitpod removed slirp4netns as part of performance improvements,
+# MTU value should be aligned to the one in gitpod.io
+#
+# Gitpod fixed it for docker - https://github.com/gitpod-io/gitpod/pull/9356
+# and for docker-compose - https://github.com/gitpod-io/template-docker-compose/pull/4
+#
+# ddev doesn't use Gitpod's custom docker-compose binary. Instead, ddev uses 
+# its own docker-compose binary at /home/gitpod/.ddev/bin/docker-compose
+# ddev issue [WIP] - https://github.com/drud/ddev/issues/3766
+# 
+# Align the MTU value to the one that is set in Gitpod (1440)
+
+networks:
+  default:
+    driver_opts:
+      com.docker.network.driver.mtu: 1440

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,54 @@
+image: drupalpod/drupalpod-gitpod-base:20240306
+
+# ddev and composer are running as part of the prebuild
+# when starting a workspace all docker images are ready
+tasks:
+  - init: |
+      ddev start -y
+      ddev composer install
+    command: |
+      ddev start -y
+      gp ports await 8080 && gp preview $(gp url 8080)
+
+# VScode xdebug extension
+vscode:
+  extensions:
+    # PHP extensions.
+    - xdebug.php-debug
+    - wongjn.php-sniffer
+    - neilbrayfield.php-docblocker
+    - bmewburn.vscode-intelephense-client
+    - andrewdavidblum.drupal-smart-snippets
+
+    # Twig extensions.
+    - mblode.twig-language-2
+
+    # Bash extensions.
+    - timonwong.shellcheck
+    - rogalmic.bash-debug
+
+ports:
+  # Used by ddev - local db clients
+  - port: 3306
+    onOpen: ignore
+  # Used by projector
+  - port: 6942
+    onOpen: ignore
+  # Used by MailHog
+  - port: 8027
+    onOpen: ignore
+  # Used by phpMyAdmin
+  - port: 8036
+    onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
+    onOpen: ignore
+  # Ignore host https port
+  - port: 8443
+    onOpen: ignore
+  # xdebug port
+  - port: 9003
+    onOpen: ignore
+  # projector port
+  - port: 9999
+    onOpen: open-browser

--- a/composer.json
+++ b/composer.json
@@ -64,6 +64,7 @@
         "centarro/commerce_kickstart": "^3.0",
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
+        "drupal/commerce_demo": "^3.0",
         "drupal/core-composer-scaffold": "^10",
         "drupal/core-project-message": "^10",
         "drupal/core-recommended": "^10",

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
             "drupal/core-composer-scaffold": true,
             "drupal/core-project-message": true,
             "oomphinc/composer-installers-extender": true,
+            "php-http/discovery" : true,
             "phpstan/extension-installer": true,
             "zaporylie/composer-drupal-optimizations": true
         }


### PR DESCRIPTION
This PR adds drupalpod support to Commerce. It is not thoroughly tested but should just work!

This is based off the commerce kickstart project and Ofer Shaal's Drupalpod works. As a consequence, this offers all the development tools in gitpod off the bat. 

You can access a test of this *dev branch* at: https://github.com/NikLP/commerce-kickstart-project/tree/gitpod-support 

This works by automagic thanks to gitpod context URLs, see: https://www.gitpod.io/docs/introduction/learn-gitpod/context-url#branch-and-commit-contexts

Notes:

- Updated the drupalpod image (compared to drupalpod repo): `drupalpod/drupalpod-gitpod-base:20240306`
- Adds extra [ddev] dir and [gitpod] file to the repo, may be unwanted
- Had to add items to composer.json - likely that the demo content may be unwanted
- Have not fully checked the veracity of the plugin

```
"allow-plugins": {
    "php-http/discovery": true
}

"require": {
    "drupal/commerce_demo": "^3.0"
}
```

